### PR TITLE
Use camelize instead of capitalize to support CamelCase model name.

### DIFF
--- a/lib/resonance/supports/converter.rb
+++ b/lib/resonance/supports/converter.rb
@@ -6,7 +6,7 @@ module Resonance
       private
 
       def classify(str)
-        str.capitalize.constantize
+        str.camelize.constantize
       end
 
       def pluralize(str)


### PR DESCRIPTION
Hi!
It's just a quick patch make `classify` to accept CamelCase model name.
